### PR TITLE
correct get_state method in rapid script

### DIFF
--- a/RAPID/SERVER_LEFT.mod
+++ b/RAPID/SERVER_LEFT.mod
@@ -314,7 +314,7 @@ MODULE SERVER_L
                     addString:=addString+NumToStr(jointsPose.robax.rax_4,2)+" ";
                     addString:=addString+NumToStr(jointsPose.robax.rax_5,2)+" ";
                     addString:=addString+NumToStr(jointsPose.robax.rax_6,2)+" ";
-                    addString:=addString+NumToStr(jointsTarget.extax.eax_a,2);
+                    addString:=addString+NumToStr(jointsPose.extax.eax_a,2);
                     !End of string
                     ok:=SERVER_OK;
                 ELSE

--- a/RAPID/SERVER_RIGHT.mod
+++ b/RAPID/SERVER_RIGHT.mod
@@ -310,7 +310,7 @@ MODULE SERVER_R
                     addString:=addString+NumToStr(jointsPose.robax.rax_5,2)+" ";
                     addString:=addString+NumToStr(jointsPose.robax.rax_6,2)+" ";
                     !addString:=addString+StrPart(NumToStr(jointsTarget.extax.eax_a,2),1,8); ! ASG: Get external axis a == joint 7
-                    addString:=addString+NumToStr(jointsTarget.extax.eax_a,2);
+                    addString:=addString+NumToStr(jointsPose.extax.eax_a,2);
                     ! ASG: Get external axis a == joint 7
                     !End of string
                     ok:=SERVER_OK;


### PR DESCRIPTION
With @jinthra, we're using yumipy on a YuMi robot. We noticed an error in the RAPID scripts "SERVER_L.mod" and "SERVER_R.mod". The error is in the get_state method, the wrong value is returned for one of the joint.

Is that on purpose or is it a bug ?